### PR TITLE
Removed ./ from the Windows executable path

### DIFF
--- a/GLSLValidator.py
+++ b/GLSLValidator.py
@@ -25,7 +25,7 @@ class glslangValidatorCommandLine:
     glslangValidatorPath = {
         "osx": "./glslangValidatorLinux",
         "linux": "./glslangValidatorLinux",
-        "windows": "./glslangValidatorWindows.exe"
+        "windows": "glslangValidatorWindows.exe"
     }
 
     def ensure_script_permissions(self):


### PR DESCRIPTION
With the ./ in the path, Windows responds with:
[b"'.' is not recognized as an internal or external command,\r\n", b'operable program or batch file.\r\n']
Without, all is well.
